### PR TITLE
Hopcroft-Karp matching algorithm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Copyright 2020 Google LLC
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~      https:www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -32,13 +48,48 @@
         <dependency>
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-api-1.0-sdk</artifactId>
-            <version>1.9.59</version>
+            <version>1.9.81</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-language</artifactId>
             <version>1.55.0</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.7.0-RC1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-testing</artifactId>
+            <version>1.9.81</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-api-stubs</artifactId>
+            <version>1.9.81</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-tools-sdk</artifactId>
+            <version>1.9.81</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client-appengine</artifactId>
+            <version>1.30.10</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/google/vinet/data/Isolate.java
+++ b/src/main/java/com/google/vinet/data/Isolate.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.vinet.data;
+
+public class Isolate extends RegisteredUser {
+  public Isolate(String userId) {
+    super(userId);
+  }
+
+}

--- a/src/main/java/com/google/vinet/data/IsolateTimeSlot.java
+++ b/src/main/java/com/google/vinet/data/IsolateTimeSlot.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.vinet.data;
+
+import java.time.Instant;
+
+public class IsolateTimeSlot extends TimeSlot {
+
+  protected IsolateTimeSlot(Instant start, Instant end, Isolate isolate) {
+    super(start, end, isolate);
+  }
+
+  public Isolate getIsolate() {
+    return (Isolate) registeredUser;
+  }
+}

--- a/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
+++ b/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
@@ -28,7 +28,7 @@ public class MatchingAlgorithm {
    * Represents a node connected to all isolate time slot nodes
    */
   public static final IsolateTimeSlot NIL_NODE =
-          new IsolateTimeSlot(Instant.MIN, Instant.MIN.plusNanos(1), null);
+          new IsolateTimeSlot(Instant.MIN, Instant.MIN.plusNanos(1), null, null, null);
 
   /**
    * An implementation of the Hopcroft-Karp algorithm to match requested help times with volunteer

--- a/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
+++ b/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
@@ -34,6 +34,10 @@ public class MatchingAlgorithm {
    * An implementation of the Hopcroft-Karp algorithm to match requested help times with volunteer
    * availability times.
    *
+   * <p>This method has a worst-case run time of O(N*M + E*sqrt(N+M)), where N is the number of
+   * volunteer time slots, M the number of isolate time slots, and E the number of edges between the
+   * two sets. The O(N*M) is due to the edge creation before running the algorithm.
+   *
    * @param isolateTimeSlots   The set of all requested time slots for help
    * @param volunteerTimeSlots The set of all time slots in which volunteers are available to help
    * @return A set of matched time slots, where a volunteer was matched to a requested time slot

--- a/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
+++ b/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
@@ -44,14 +44,7 @@ public class MatchingAlgorithm {
    */
   public static Set<IsolateTimeSlot> matchTimeSlots(
           Set<IsolateTimeSlot> isolateTimeSlots, Set<VolunteerTimeSlot> volunteerTimeSlots) {
-
-    if (isolateTimeSlots == null || volunteerTimeSlots == null)
-      throw new IllegalArgumentException("Null argument!");
-
-    // Remove null nodes, if present
-    isolateTimeSlots.remove(null);
-    volunteerTimeSlots.remove(null);
-
+    validateTimeSlotsInput(isolateTimeSlots, volunteerTimeSlots);
     addEdges(isolateTimeSlots, volunteerTimeSlots);
     isolateTimeSlots.add(NIL_NODE);
 
@@ -64,6 +57,16 @@ public class MatchingAlgorithm {
     }
 
     return isolateTimeSlots.stream().filter(TimeSlot::isPaired).collect(Collectors.toSet());
+  }
+
+  private static void validateTimeSlotsInput(
+          Set<IsolateTimeSlot> isolateTimeSlots, Set<VolunteerTimeSlot> volunteerTimeSlots) {
+    if (isolateTimeSlots == null || volunteerTimeSlots == null)
+      throw new IllegalArgumentException("Null argument!");
+
+    // Remove null nodes, if present
+    isolateTimeSlots.remove(null);
+    volunteerTimeSlots.remove(null);
   }
 
   /**

--- a/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
+++ b/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
@@ -1,17 +1,17 @@
 /*
- * Copyright 2020 Google LLC
+ *  Copyright 2020 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ *      https:www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package com.google.vinet.data;
@@ -82,15 +82,6 @@ public class MatchingAlgorithm {
         // TODO consider the case where volunteer time slot is longer than isolate's
         // we could run the algorithm again with the remaining isolate slots and the chunks of
         // volunteer time slots that were not assigned
-
-        // Remove time slot if any of its instants are null
-        if (volunteerTimeSlot.getStart() == null || volunteerTimeSlot.getEnd() == null) {
-          volunteerTimeSlots.remove(volunteerTimeSlot);
-          continue;
-        } else if (isolateTimeSlot.getStart() == null || isolateTimeSlot.getEnd() == null) {
-          isolateTimeSlots.remove(isolateTimeSlot);
-          continue;
-        }
 
         if (volunteerTimeSlot.contains(isolateTimeSlot)) {
           isolateTimeSlot.addNeighbour(volunteerTimeSlot);

--- a/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
+++ b/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
@@ -28,7 +28,7 @@ public class MatchingAlgorithm {
    * Represents a node connected to all isolate time slot nodes
    */
   public static final IsolateTimeSlot NIL_NODE =
-          new IsolateTimeSlot(Instant.MIN, Instant.MIN, null);
+          new IsolateTimeSlot(Instant.MIN, Instant.MIN.plusNanos(1), null);
 
   /**
    * An implementation of the Hopcroft-Karp algorithm to match requested help times with volunteer

--- a/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
+++ b/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
@@ -58,16 +58,18 @@ public class MatchingAlgorithm {
   /**
    * Adds edges between the two sets of time slots, based on availability constraints.
    *
-   * <p>Adds an edge if a volunteer time slot is contained by any isolate time slot.
+   * <p>Adds an edge if a volunteer time slot contains an isolate time slot.
+   *
+   * <p>This is an N*M operation, where N is the number of isolate time slots and M the number of
+   * volunteer time slots.
    */
   private static void addEdges(
           Set<IsolateTimeSlot> isolateTimeSlots, Set<VolunteerTimeSlot> volunteerTimeSlots) {
-    // For each volunteer time slot, check if it is contained by each isolate time slot.
-    // if yes, add as a neighbour to both. This is an N*M operation.
     for (VolunteerTimeSlot volunteerTimeSlot : volunteerTimeSlots) {
       for (IsolateTimeSlot isolateTimeSlot : isolateTimeSlots) {
         // TODO check if within geographic range
-        if (isolateTimeSlot.contains(volunteerTimeSlot)) {
+        // TODO consider the case where volunteer time slot is longer than isolate's
+        if (volunteerTimeSlot.contains(isolateTimeSlot)) {
           isolateTimeSlot.addNeighbour(volunteerTimeSlot);
           volunteerTimeSlot.addNeighbour(isolateTimeSlot);
         }

--- a/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
+++ b/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
@@ -34,9 +34,6 @@ public class MatchingAlgorithm {
    * An implementation of the Hopcroft-Karp algorithm to match requested help times with volunteer
    * availability times.
    *
-   * <p>The time slots must all belong to the same day. The algorithm also ensures a maximum
-   * distance for volunteer action.
-   *
    * @param isolateTimeSlots   The set of all requested time slots for help
    * @param volunteerTimeSlots The set of all time slots in which volunteers are available to help
    * @return A set of matched time slots, where a volunteer was matched to a requested time slot

--- a/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
+++ b/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
@@ -41,6 +41,13 @@ public class MatchingAlgorithm {
   public static Set<IsolateTimeSlot> matchTimeSlots(
           Set<IsolateTimeSlot> isolateTimeSlots, Set<VolunteerTimeSlot> volunteerTimeSlots) {
 
+    if (isolateTimeSlots == null || volunteerTimeSlots == null)
+      throw new IllegalArgumentException("Null argument!");
+
+    // Remove null nodes, if present
+    isolateTimeSlots.remove(null);
+    volunteerTimeSlots.remove(null);
+
     addEdges(isolateTimeSlots, volunteerTimeSlots);
     isolateTimeSlots.add(NIL_NODE);
 
@@ -69,6 +76,18 @@ public class MatchingAlgorithm {
       for (IsolateTimeSlot isolateTimeSlot : isolateTimeSlots) {
         // TODO check if within geographic range
         // TODO consider the case where volunteer time slot is longer than isolate's
+        // we could run the algorithm again with the remaining isolate slots and the chunks of
+        // volunteer time slots that were not assigned
+
+        // Remove time slot if any of its instants are null
+        if (volunteerTimeSlot.getStart() == null || volunteerTimeSlot.getEnd() == null) {
+          volunteerTimeSlots.remove(volunteerTimeSlot);
+          continue;
+        } else if (isolateTimeSlot.getStart() == null || isolateTimeSlot.getEnd() == null) {
+          isolateTimeSlots.remove(isolateTimeSlot);
+          continue;
+        }
+
         if (volunteerTimeSlot.contains(isolateTimeSlot)) {
           isolateTimeSlot.addNeighbour(volunteerTimeSlot);
           volunteerTimeSlot.addNeighbour(isolateTimeSlot);
@@ -113,6 +132,12 @@ public class MatchingAlgorithm {
     return NIL_NODE.getDistance() != Double.POSITIVE_INFINITY;
   }
 
+  /**
+   * Performs depth-first search from the given time slot to the first unmatched time slot it finds
+   *
+   * @param slot The slot to use as a starting point for the search
+   * @return Whether the search found an unmatched slot
+   */
   private static boolean depthFirstSearch(TimeSlot slot) {
     if (slot.equals(NIL_NODE)) return true;
     for (TimeSlot neighbour : slot.getNeighbours()) {

--- a/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
+++ b/src/main/java/com/google/vinet/data/MatchingAlgorithm.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.vinet.data;
+
+import java.util.Set;
+
+public class MatchingAlgorithm {
+
+  /**
+   * An implementation of the Hopcroft-Karp algorithm to match requested help times with volunteer
+   * availability times.
+   *
+   * <p>The time slots must all belong to the same day. The algorithm also ensures a maximum
+   * distance for volunteer action.
+   *
+   * @param isolateTimeSlots   The set of all requested time slots for help
+   * @param volunteerTimeSlots The set of all time slots in which volunteers are available to help
+   * @return A set of matched time slots, where a volunteer was matched to a requested time slot
+   */
+  public static Set<MatchedTimeSlot> matchTimeSlots(
+          Set<IsolateTimeSlot> isolateTimeSlots, Set<VolunteerTimeSlot> volunteerTimeSlots) {
+    // First step: add edges
+    // For each volunteer time slot, check if it is contained by each isolate time slot.
+    // if yes, add as a neighbour to both. This is an N^2 operation.
+    for (VolunteerTimeSlot volunteerTimeSlot : volunteerTimeSlots) {
+      for (IsolateTimeSlot isolateTimeSlot : isolateTimeSlots) {
+        //TODO check if within geographic range
+        if (isolateTimeSlot.contains(volunteerTimeSlot)) {
+          isolateTimeSlot.addNeighbour(volunteerTimeSlot);
+          volunteerTimeSlot.addNeighbour(isolateTimeSlot);
+        }
+      }
+    }
+
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/main/java/com/google/vinet/data/RegisteredUser.java
+++ b/src/main/java/com/google/vinet/data/RegisteredUser.java
@@ -19,7 +19,7 @@ package com.google.vinet.data;
 import java.util.Objects;
 
 public class RegisteredUser {
-  private final String userId;
+  protected final String userId;
 
   public RegisteredUser(String userId) {
     this.userId = Objects.requireNonNull(userId, "User ID must not be null!");

--- a/src/main/java/com/google/vinet/data/RegisteredUser.java
+++ b/src/main/java/com/google/vinet/data/RegisteredUser.java
@@ -16,11 +16,13 @@
 
 package com.google.vinet.data;
 
+import java.util.Objects;
+
 public class RegisteredUser {
   private final String userId;
 
   public RegisteredUser(String userId) {
-    this.userId = userId;
+    this.userId = Objects.requireNonNull(userId, "User ID must not be null!");
   }
 
   @Override

--- a/src/main/java/com/google/vinet/data/RegisteredUser.java
+++ b/src/main/java/com/google/vinet/data/RegisteredUser.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.vinet.data;
+
+public class RegisteredUser {
+  private final String userId;
+
+  public RegisteredUser(String userId) {
+    this.userId = userId;
+  }
+
+  @Override
+  public int hashCode() {
+    return userId.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (this.getClass() != obj.getClass()) return false;
+    RegisteredUser registeredUser = ((RegisteredUser) obj);
+    return userId.equals(registeredUser.userId);
+  }
+}

--- a/src/main/java/com/google/vinet/data/TimeSlot.java
+++ b/src/main/java/com/google/vinet/data/TimeSlot.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.vinet.data;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class TimeSlot implements Comparable<TimeSlot> {
+
+  private final Instant start;
+  private final Instant end;
+  private final Set<TimeSlot> neighbours = new HashSet<>();
+
+  protected TimeSlot(Instant start, Instant end) {
+    this.start = start;
+    this.end = end;
+  }
+
+  public Instant getStart() {
+    return start;
+  }
+
+  public Instant getEnd() {
+    return end;
+  }
+
+  public Set<TimeSlot> getNeighbours() {
+    return Collections.unmodifiableSet(neighbours);
+  }
+
+  public void addNeighbour(TimeSlot timeSlot) {
+    neighbours.add(timeSlot);
+  }
+
+  public void removeNeighbour(TimeSlot timeSlot) {
+    neighbours.remove(timeSlot);
+  }
+
+  /**
+   * Compares two time slots based on their start time
+   */
+  @Override
+  public int compareTo(TimeSlot timeSlot) {
+    return start.compareTo(timeSlot.getStart());
+  }
+
+  public static Comparator<TimeSlot> TimeSlotEndComparator = Comparator.comparing(TimeSlot::getEnd);
+
+  /**
+   * Checks whether this timeslot contains another
+   *
+   * @param timeSlot The slot that is to be contained
+   * @return Whether this slot contains the specified slot
+   */
+  public boolean contains(TimeSlot timeSlot) {
+    return compareTo(timeSlot) >= 0 && TimeSlotEndComparator.compare(this, timeSlot) <= 0;
+  }
+}

--- a/src/main/java/com/google/vinet/data/TimeSlot.java
+++ b/src/main/java/com/google/vinet/data/TimeSlot.java
@@ -1,22 +1,23 @@
 /*
- * Copyright 2020 Google LLC
+ *  Copyright 2020 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ *      https:www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package com.google.vinet.data;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -99,6 +100,15 @@ public abstract class TimeSlot implements Comparable<TimeSlot> {
    */
   public boolean contains(TimeSlot timeSlot) {
     return compareTo(timeSlot) <= 0 && TimeSlotEndComparator.compare(this, timeSlot) >= 0;
+  }
+
+  public boolean hasMinimumOverlap(TimeSlot timeSlot, long minMinutesOverlap) {
+    if (start.isBefore(timeSlot.start)) {
+      // If difference is negative, they don't overlap, and will return false.
+      return ChronoUnit.MINUTES.between(timeSlot.start, end) > minMinutesOverlap;
+    } else {
+      return ChronoUnit.MINUTES.between(start, timeSlot.end) > minMinutesOverlap;
+    }
   }
 
   @Override

--- a/src/main/java/com/google/vinet/data/TimeSlot.java
+++ b/src/main/java/com/google/vinet/data/TimeSlot.java
@@ -29,6 +29,8 @@ public abstract class TimeSlot implements Comparable<TimeSlot> {
   private final Instant end;
   protected final RegisteredUser registeredUser;
   private final Set<TimeSlot> neighbours = new HashSet<>();
+  private TimeSlot pairedSlot = null;
+  private double distance = 0;
 
   protected TimeSlot(Instant start, Instant end, RegisteredUser registeredUser) {
     this.start = start;
@@ -44,16 +46,32 @@ public abstract class TimeSlot implements Comparable<TimeSlot> {
     return end;
   }
 
+  public double getDistance() {
+    return distance;
+  }
+
+  public void setDistance(double distance) {
+    this.distance = distance;
+  }
+
+  public boolean isPaired() {
+    return pairedSlot != null;
+  }
+
+  public TimeSlot getPairedSlot() {
+    return pairedSlot == null ? MatchingAlgorithm.NIL_NODE : pairedSlot;
+  }
+
+  public void setPairedSlot(TimeSlot pairedSlot) {
+    this.pairedSlot = pairedSlot;
+  }
+
   public Set<TimeSlot> getNeighbours() {
     return Collections.unmodifiableSet(neighbours);
   }
 
   public void addNeighbour(TimeSlot timeSlot) {
     neighbours.add(timeSlot);
-  }
-
-  public void removeNeighbour(TimeSlot timeSlot) {
-    neighbours.remove(timeSlot);
   }
 
   /**
@@ -76,15 +94,14 @@ public abstract class TimeSlot implements Comparable<TimeSlot> {
     return compareTo(timeSlot) >= 0 && TimeSlotEndComparator.compare(this, timeSlot) <= 0;
   }
 
-
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     TimeSlot timeSlot = (TimeSlot) o;
-    return Objects.equals(start, timeSlot.start) &&
-            Objects.equals(end, timeSlot.end) &&
-            Objects.equals(registeredUser, timeSlot.registeredUser);
+    return Objects.equals(start, timeSlot.start)
+            && Objects.equals(end, timeSlot.end)
+            && Objects.equals(registeredUser, timeSlot.registeredUser);
   }
 
   @Override

--- a/src/main/java/com/google/vinet/data/TimeSlot.java
+++ b/src/main/java/com/google/vinet/data/TimeSlot.java
@@ -22,7 +22,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
-public abstract class TimeSlot implements Comparable<TimeSlot> {
+public abstract class TimeSlot {
 
   private final Instant start;
   private final Instant end;
@@ -89,7 +89,8 @@ public abstract class TimeSlot implements Comparable<TimeSlot> {
    * @return Whether this slot contains the specified slot
    */
   public boolean contains(TimeSlot timeSlot) {
-    return start.isBefore(timeSlot.start) && end.isAfter(timeSlot.end);
+    return (start.equals(timeSlot.start) || start.isBefore(timeSlot.start))
+            && (end.equals(timeSlot.end) || end.isAfter(timeSlot.end));
   }
 
   @Override

--- a/src/main/java/com/google/vinet/data/TimeSlot.java
+++ b/src/main/java/com/google/vinet/data/TimeSlot.java
@@ -17,9 +17,7 @@
 package com.google.vinet.data;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -84,14 +82,6 @@ public abstract class TimeSlot implements Comparable<TimeSlot> {
     neighbours.add(timeSlot);
   }
 
-  /** Compares two time slots based on their start time */
-  @Override
-  public int compareTo(TimeSlot timeSlot) {
-    return start.compareTo(timeSlot.getStart());
-  }
-
-  public static Comparator<TimeSlot> TimeSlotEndComparator = Comparator.comparing(TimeSlot::getEnd);
-
   /**
    * Checks whether this timeslot contains another
    *
@@ -99,16 +89,7 @@ public abstract class TimeSlot implements Comparable<TimeSlot> {
    * @return Whether this slot contains the specified slot
    */
   public boolean contains(TimeSlot timeSlot) {
-    return compareTo(timeSlot) <= 0 && TimeSlotEndComparator.compare(this, timeSlot) >= 0;
-  }
-
-  public boolean hasMinimumOverlap(TimeSlot timeSlot, long minMinutesOverlap) {
-    if (start.isBefore(timeSlot.start)) {
-      // If difference is negative, they don't overlap, and will return false.
-      return ChronoUnit.MINUTES.between(timeSlot.start, end) > minMinutesOverlap;
-    } else {
-      return ChronoUnit.MINUTES.between(start, timeSlot.end) > minMinutesOverlap;
-    }
+    return start.isBefore(timeSlot.start) && end.isAfter(timeSlot.end);
   }
 
   @Override

--- a/src/main/java/com/google/vinet/data/TimeSlot.java
+++ b/src/main/java/com/google/vinet/data/TimeSlot.java
@@ -33,6 +33,8 @@ public abstract class TimeSlot implements Comparable<TimeSlot> {
   private double distance = 0;
 
   protected TimeSlot(Instant start, Instant end, RegisteredUser registeredUser) {
+    if (start == null || end == null) throw new NullPointerException();
+    if (start.isAfter(end)) throw new IllegalArgumentException();
     this.start = start;
     this.end = end;
     this.registeredUser = registeredUser;

--- a/src/main/java/com/google/vinet/data/TimeSlot.java
+++ b/src/main/java/com/google/vinet/data/TimeSlot.java
@@ -20,17 +20,20 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 public abstract class TimeSlot implements Comparable<TimeSlot> {
 
   private final Instant start;
   private final Instant end;
+  protected final RegisteredUser registeredUser;
   private final Set<TimeSlot> neighbours = new HashSet<>();
 
-  protected TimeSlot(Instant start, Instant end) {
+  protected TimeSlot(Instant start, Instant end, RegisteredUser registeredUser) {
     this.start = start;
     this.end = end;
+    this.registeredUser = registeredUser;
   }
 
   public Instant getStart() {
@@ -71,5 +74,21 @@ public abstract class TimeSlot implements Comparable<TimeSlot> {
    */
   public boolean contains(TimeSlot timeSlot) {
     return compareTo(timeSlot) >= 0 && TimeSlotEndComparator.compare(this, timeSlot) <= 0;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TimeSlot timeSlot = (TimeSlot) o;
+    return Objects.equals(start, timeSlot.start) &&
+            Objects.equals(end, timeSlot.end) &&
+            Objects.equals(registeredUser, timeSlot.registeredUser);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(start, end, registeredUser);
   }
 }

--- a/src/main/java/com/google/vinet/data/TimeSlot.java
+++ b/src/main/java/com/google/vinet/data/TimeSlot.java
@@ -32,11 +32,18 @@ public abstract class TimeSlot implements Comparable<TimeSlot> {
   private TimeSlot pairedSlot = null;
   private double distance = 0;
 
-  protected TimeSlot(Instant start, Instant end, RegisteredUser registeredUser) {
-    if (start == null || end == null) throw new NullPointerException();
+  /**
+   * Create a new time slot. Start and end times must not be null, and start time must come before
+   * end time.
+   *
+   * @param start          The starting instant for the slot.
+   * @param end            The ending instant for the slot.
+   * @param registeredUser The user for which this slot applies.
+   */
+  public TimeSlot(Instant start, Instant end, RegisteredUser registeredUser) {
+    this.start = Objects.requireNonNull(start, "Start time must not be null!");
+    this.end = Objects.requireNonNull(end, "End time must not be null!");
     if (start.isAfter(end)) throw new IllegalArgumentException();
-    this.start = start;
-    this.end = end;
     this.registeredUser = registeredUser;
   }
 
@@ -76,9 +83,7 @@ public abstract class TimeSlot implements Comparable<TimeSlot> {
     neighbours.add(timeSlot);
   }
 
-  /**
-   * Compares two time slots based on their start time
-   */
+  /** Compares two time slots based on their start time */
   @Override
   public int compareTo(TimeSlot timeSlot) {
     return start.compareTo(timeSlot.getStart());

--- a/src/main/java/com/google/vinet/data/TimeSlot.java
+++ b/src/main/java/com/google/vinet/data/TimeSlot.java
@@ -91,7 +91,7 @@ public abstract class TimeSlot implements Comparable<TimeSlot> {
    * @return Whether this slot contains the specified slot
    */
   public boolean contains(TimeSlot timeSlot) {
-    return compareTo(timeSlot) >= 0 && TimeSlotEndComparator.compare(this, timeSlot) <= 0;
+    return compareTo(timeSlot) <= 0 && TimeSlotEndComparator.compare(this, timeSlot) >= 0;
   }
 
   @Override

--- a/src/main/java/com/google/vinet/data/TimeSlot.java
+++ b/src/main/java/com/google/vinet/data/TimeSlot.java
@@ -44,7 +44,7 @@ public abstract class TimeSlot implements Comparable<TimeSlot> {
   public TimeSlot(Instant start, Instant end, RegisteredUser registeredUser) {
     this.start = Objects.requireNonNull(start, "Start time must not be null!");
     this.end = Objects.requireNonNull(end, "End time must not be null!");
-    if (start.isAfter(end)) throw new IllegalArgumentException();
+    if (!start.isBefore(end)) throw new IllegalArgumentException();
     this.registeredUser = registeredUser;
   }
 

--- a/src/main/java/com/google/vinet/data/Volunteer.java
+++ b/src/main/java/com/google/vinet/data/Volunteer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.vinet.data;
+
+public class Volunteer extends RegisteredUser {
+
+    public Volunteer(String userId) {
+        super(userId);
+    }
+
+}

--- a/src/main/java/com/google/vinet/data/VolunteerTimeSlot.java
+++ b/src/main/java/com/google/vinet/data/VolunteerTimeSlot.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.vinet.data;
+
+import java.time.Instant;
+
+public class VolunteerTimeSlot extends TimeSlot {
+
+  protected VolunteerTimeSlot(Instant start, Instant end, Volunteer volunteer) {
+    super(start, end, volunteer);
+  }
+
+  public Volunteer getVolunteer() {
+    return (Volunteer) registeredUser;
+  }
+}

--- a/src/main/java/com/google/vinet/data/VolunteerTimeSlot.java
+++ b/src/main/java/com/google/vinet/data/VolunteerTimeSlot.java
@@ -20,7 +20,7 @@ import java.time.Instant;
 
 public class VolunteerTimeSlot extends TimeSlot {
 
-  protected VolunteerTimeSlot(Instant start, Instant end, Volunteer volunteer) {
+  public VolunteerTimeSlot(Instant start, Instant end, Volunteer volunteer) {
     super(start, end, volunteer);
   }
 

--- a/src/test/java/com/google/vinet/data/MatchingAlgorithmTest.java
+++ b/src/test/java/com/google/vinet/data/MatchingAlgorithmTest.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static java.time.temporal.ChronoUnit.HOURS;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MatchingAlgorithmTest {
 
@@ -44,12 +45,12 @@ public class MatchingAlgorithmTest {
     VolunteerTimeSlot volunteerSlot = new VolunteerTimeSlot(now, now.plus(1, HOURS), null);
     isolateTimeSlots.add(isolateSlot);
     volunteerTimeSlots.add(volunteerSlot);
-    Set<IsolateTimeSlot> matched = MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
     assert (matched.contains(isolateSlot));
     assert (isolateSlot.isPaired());
     assert (isolateSlot.getPairedSlot() == volunteerSlot);
   }
-
 
   @Test
   public void testOneRequestOneVolunteerNoMatch() {
@@ -57,7 +58,8 @@ public class MatchingAlgorithmTest {
     VolunteerTimeSlot volunteerSlot = new VolunteerTimeSlot(now, now.plus(1, HOURS), null);
     isolateTimeSlots.add(isolateSlot);
     volunteerTimeSlots.add(volunteerSlot);
-    Set<IsolateTimeSlot> matched = MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
     assert (!matched.contains(isolateSlot));
     assert (!isolateSlot.isPaired());
     assert (isolateSlot.getPairedSlot() != volunteerSlot);
@@ -69,7 +71,8 @@ public class MatchingAlgorithmTest {
     VolunteerTimeSlot volunteerSlot = new VolunteerTimeSlot(now, now.plus(2, HOURS), null);
     isolateTimeSlots.add(isolateSlot);
     volunteerTimeSlots.add(volunteerSlot);
-    Set<IsolateTimeSlot> matched = MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
     assert (matched.contains(isolateSlot));
     assert (isolateSlot.isPaired());
     assert (isolateSlot.getPairedSlot() == volunteerSlot);
@@ -83,33 +86,138 @@ public class MatchingAlgorithmTest {
   @Test
   public void testTwoRequestsOneVolunteerVolunteerTooLongMatch() {
     IsolateTimeSlot isolateSlot1 = new IsolateTimeSlot(now, now.plus(1, HOURS), null);
-    IsolateTimeSlot isolateSlot2 = new IsolateTimeSlot(now.plus(1, HOURS), now.plus(2, HOURS), null);
+    IsolateTimeSlot isolateSlot2 =
+            new IsolateTimeSlot(now.plus(1, HOURS), now.plus(2, HOURS), null);
     VolunteerTimeSlot volunteerSlot = new VolunteerTimeSlot(now, now.plus(2, HOURS), null);
     isolateTimeSlots.add(isolateSlot1);
     isolateTimeSlots.add(isolateSlot2);
     volunteerTimeSlots.add(volunteerSlot);
-    Set<IsolateTimeSlot> matched = MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
     assert (matched.size() == 1);
   }
 
   @Test
   public void testTwoRequestsTwoVolunteersVolunteerTooLongMatch() {
     IsolateTimeSlot isolateSlot1 = new IsolateTimeSlot(now, now.plus(1, HOURS), null);
-    IsolateTimeSlot isolateSlot2 = new IsolateTimeSlot(now.plus(1, HOURS), now.plus(2, HOURS), null);
+    IsolateTimeSlot isolateSlot2 =
+            new IsolateTimeSlot(now.plus(1, HOURS), now.plus(2, HOURS), null);
     VolunteerTimeSlot volunteerSlot1 = new VolunteerTimeSlot(now, now.plus(2, HOURS), null);
     VolunteerTimeSlot volunteerSlot2 = new VolunteerTimeSlot(now, now.plus(1, HOURS), null);
     isolateTimeSlots.add(isolateSlot1);
     isolateTimeSlots.add(isolateSlot2);
     volunteerTimeSlots.add(volunteerSlot1);
     volunteerTimeSlots.add(volunteerSlot2);
-    Set<IsolateTimeSlot> matched = MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
     assert (matched.size() == 2);
     assert (isolateSlot1.getPairedSlot() != (isolateSlot2.getPairedSlot()));
   }
 
+  @Test
+  public void testNullIsolates() {
+    VolunteerTimeSlot volunteerSlot1 = new VolunteerTimeSlot(now, now.plus(2, HOURS), null);
+    volunteerTimeSlots.add(volunteerSlot1);
+    assertThrows(
+            IllegalArgumentException.class,
+            () -> MatchingAlgorithm.matchTimeSlots(null, volunteerTimeSlots));
+  }
 
-  //TODO test with no volunteers
-  //TODO test with no isolates
-  //TODO test with neither
-  //TODO test with null sets
+  @Test
+  public void testNullVolunteers() {
+    IsolateTimeSlot isolateSlot1 = new IsolateTimeSlot(now, now.plus(1, HOURS), null);
+    isolateTimeSlots.add(isolateSlot1);
+    assertThrows(
+            IllegalArgumentException.class,
+            () -> MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, null));
+  }
+
+  @Test
+  public void testNullSets() {
+    assertThrows(
+            IllegalArgumentException.class, () -> MatchingAlgorithm.matchTimeSlots(null, null));
+  }
+
+  @Test
+  public void testNoVolunteers() {
+    isolateTimeSlots.add(new IsolateTimeSlot(now, now.plus(1, HOURS), null));
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    assert (matched.size() == 0);
+  }
+
+  @Test
+  public void testNoIsolates() {
+    volunteerTimeSlots.add(new VolunteerTimeSlot(now, now.plus(2, HOURS), null));
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    assert (matched.size() == 0);
+  }
+
+  @Test
+  public void testEmptySets() {
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    assert (matched.size() == 0);
+  }
+
+  @Test
+  public void testNullIsolateSlot() {
+    isolateTimeSlots.add(null);
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    assert (matched.size() == 0);
+  }
+
+  @Test
+  public void testNullVolunteerSlot() {
+    volunteerTimeSlots.add(null);
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    assert (matched.size() == 0);
+  }
+
+  @Test
+  public void testNullSlots() {
+    volunteerTimeSlots.add(null);
+    isolateTimeSlots.add(null);
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    assert (matched.size() == 0);
+  }
+
+  @Test
+  public void testNullStartTime() {
+    assertThrows(
+            NullPointerException.class,
+            () -> isolateTimeSlots.add(new IsolateTimeSlot(null, now.plus(1, HOURS), null)));
+    volunteerTimeSlots.add(new VolunteerTimeSlot(now, now.plus(2, HOURS), null));
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    assert (matched.size() == 0);
+  }
+
+  @Test
+  public void testNullEndTime() {
+    assertThrows(
+            NullPointerException.class,
+            () -> isolateTimeSlots.add(new IsolateTimeSlot(now, null, null)));
+    volunteerTimeSlots.add(new VolunteerTimeSlot(now, now.plus(2, HOURS), null));
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    assert (matched.size() == 0);
+  }
+
+  @Test
+  public void testStartAfterEnd() {
+    assertThrows(
+            IllegalArgumentException.class,
+            () -> isolateTimeSlots.add(new IsolateTimeSlot(now.plus(1, HOURS), now, null)));
+    assertThrows(
+            IllegalArgumentException.class,
+            () -> volunteerTimeSlots.add(new VolunteerTimeSlot(now.plus(1, HOURS), now, null)));
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    assert (matched.size() == 0);
+  }
 }

--- a/src/test/java/com/google/vinet/data/MatchingAlgorithmTest.java
+++ b/src/test/java/com/google/vinet/data/MatchingAlgorithmTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.vinet.data;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.time.temporal.ChronoUnit.HOURS;
+
+public class MatchingAlgorithmTest {
+
+  private Set<IsolateTimeSlot> isolateTimeSlots;
+  private Set<VolunteerTimeSlot> volunteerTimeSlots;
+
+  @BeforeEach
+  public void initialiseSets() {
+    isolateTimeSlots = new HashSet<>();
+    volunteerTimeSlots = new HashSet<>();
+  }
+
+  @Test
+  public void testOneRequestOneVolunteerMatch() {
+    Instant now = Instant.now();
+    IsolateTimeSlot isolateSlot = new IsolateTimeSlot(now, now.plus(1, HOURS), null);
+    VolunteerTimeSlot volunteerSlot = new VolunteerTimeSlot(now, now.plus(1, HOURS), null);
+    isolateTimeSlots.add(isolateSlot);
+    volunteerTimeSlots.add(volunteerSlot);
+    Set<IsolateTimeSlot> matched = MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    assert (matched.contains(isolateSlot));
+    assert (isolateSlot.isPaired());
+    assert (isolateSlot.getPairedSlot().equals(volunteerSlot));
+  }
+}

--- a/src/test/java/com/google/vinet/data/MatchingAlgorithmTest.java
+++ b/src/test/java/com/google/vinet/data/MatchingAlgorithmTest.java
@@ -47,7 +47,7 @@ public class MatchingAlgorithmTest {
     Set<IsolateTimeSlot> matched = MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
     assert (matched.contains(isolateSlot));
     assert (isolateSlot.isPaired());
-    assert (isolateSlot.getPairedSlot().equals(volunteerSlot));
+    assert (isolateSlot.getPairedSlot() == volunteerSlot);
   }
 
 
@@ -60,7 +60,7 @@ public class MatchingAlgorithmTest {
     Set<IsolateTimeSlot> matched = MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
     assert (!matched.contains(isolateSlot));
     assert (!isolateSlot.isPaired());
-    assert (!isolateSlot.getPairedSlot().equals(volunteerSlot));
+    assert (isolateSlot.getPairedSlot() != volunteerSlot);
   }
 
   @Test
@@ -72,7 +72,7 @@ public class MatchingAlgorithmTest {
     Set<IsolateTimeSlot> matched = MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
     assert (matched.contains(isolateSlot));
     assert (isolateSlot.isPaired());
-    assert (isolateSlot.getPairedSlot().equals(volunteerSlot));
+    assert (isolateSlot.getPairedSlot() == volunteerSlot);
   }
 
   /**
@@ -104,6 +104,12 @@ public class MatchingAlgorithmTest {
     volunteerTimeSlots.add(volunteerSlot2);
     Set<IsolateTimeSlot> matched = MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
     assert (matched.size() == 2);
-    assert (!isolateSlot1.getPairedSlot().equals(isolateSlot2.getPairedSlot()));
+    assert (isolateSlot1.getPairedSlot() != (isolateSlot2.getPairedSlot()));
   }
+
+
+  //TODO test with no volunteers
+  //TODO test with no isolates
+  //TODO test with neither
+  //TODO test with null sets
 }

--- a/src/test/java/com/google/vinet/data/MatchingAlgorithmTest.java
+++ b/src/test/java/com/google/vinet/data/MatchingAlgorithmTest.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MatchingAlgorithmTest {
@@ -260,5 +261,24 @@ public class MatchingAlgorithmTest {
     Set<IsolateTimeSlot> matched =
             MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
     assert (matched.size() == 5);
+  }
+
+  @Test
+  public void testTwentyVolunteersTenIsolatesOverlappingAllMatch() {
+    for (int i = 0; i < 10; i++) {
+      isolateTimeSlots.add(new IsolateTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
+      isolateTimeSlots.add(
+              new IsolateTimeSlot(now.plus(i, HOURS).plus(30, MINUTES), now.plus(i + 1, HOURS), null));
+    }
+    for (int i = 0; i < 10; i++) {
+      volunteerTimeSlots.add(
+              new VolunteerTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
+      volunteerTimeSlots.add(
+              new VolunteerTimeSlot(now.plus(i, HOURS), now.plus(i + 2, HOURS), null));
+    }
+
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    assert (matched.size() == 20);
   }
 }

--- a/src/test/java/com/google/vinet/data/MatchingAlgorithmTest.java
+++ b/src/test/java/com/google/vinet/data/MatchingAlgorithmTest.java
@@ -1,17 +1,17 @@
 /*
- *  Copyright 2020 Google LLC
+ * Copyright 2020 Google LLC
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      https:www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.google.vinet.data;
@@ -20,11 +20,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.HashSet;
 import java.util.Set;
+import java.time.Clock;
 
 import static java.time.temporal.ChronoUnit.HOURS;
-import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MatchingAlgorithmTest {
@@ -32,12 +33,14 @@ public class MatchingAlgorithmTest {
   private Set<IsolateTimeSlot> isolateTimeSlots;
   private Set<VolunteerTimeSlot> volunteerTimeSlots;
   private Instant now;
+  /** This reference time is arbitrary. It is simply a fixed point in time. */
+  private static final String DEFAULT_TEST_TIME = "2020-09-01T12:00:00Z";
 
   @BeforeEach
   public void initialiseSets() {
     isolateTimeSlots = new HashSet<>();
     volunteerTimeSlots = new HashSet<>();
-    now = Instant.now();
+    now = Clock.fixed(Instant.parse(DEFAULT_TEST_TIME), ZoneId.systemDefault()).instant();
   }
 
   @Test
@@ -220,65 +223,5 @@ public class MatchingAlgorithmTest {
     Set<IsolateTimeSlot> matched =
             MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
     assert (matched.size() == 0);
-  }
-
-  @Test
-  public void testTenVolunteersTenIsolatesMatchAll() {
-    for (int i = 0; i < 10; i++) {
-      isolateTimeSlots.add(new IsolateTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
-      volunteerTimeSlots.add(
-              new VolunteerTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
-    }
-
-    Set<IsolateTimeSlot> matched =
-            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
-    assert (matched.size() == 10);
-  }
-
-  @Test
-  public void test100VolunteersTenIsolatesMatchAll() {
-    for (int i = 0; i < 100; i++) {
-      isolateTimeSlots.add(new IsolateTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
-      volunteerTimeSlots.add(
-              new VolunteerTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
-    }
-
-    Set<IsolateTimeSlot> matched =
-            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
-    assert (matched.size() == 100);
-  }
-
-  @Test
-  public void testTenVolunteersTenIsolatesHalfMatch() {
-    for (int i = 0; i < 10; i++) {
-      isolateTimeSlots.add(new IsolateTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
-    }
-    for (int i = 5; i < 15; i++) {
-      volunteerTimeSlots.add(
-              new VolunteerTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
-    }
-
-    Set<IsolateTimeSlot> matched =
-            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
-    assert (matched.size() == 5);
-  }
-
-  @Test
-  public void testTwentyVolunteersTenIsolatesOverlappingAllMatch() {
-    for (int i = 0; i < 10; i++) {
-      isolateTimeSlots.add(new IsolateTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
-      isolateTimeSlots.add(
-              new IsolateTimeSlot(now.plus(i, HOURS).plus(30, MINUTES), now.plus(i + 1, HOURS), null));
-    }
-    for (int i = 0; i < 10; i++) {
-      volunteerTimeSlots.add(
-              new VolunteerTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
-      volunteerTimeSlots.add(
-              new VolunteerTimeSlot(now.plus(i, HOURS), now.plus(i + 2, HOURS), null));
-    }
-
-    Set<IsolateTimeSlot> matched =
-            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
-    assert (matched.size() == 20);
   }
 }

--- a/src/test/java/com/google/vinet/data/MatchingAlgorithmTest.java
+++ b/src/test/java/com/google/vinet/data/MatchingAlgorithmTest.java
@@ -1,17 +1,17 @@
 /*
- * Copyright 2020 Google LLC
+ *  Copyright 2020 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ *      https:www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package com.google.vinet.data;
@@ -219,5 +219,46 @@ public class MatchingAlgorithmTest {
     Set<IsolateTimeSlot> matched =
             MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
     assert (matched.size() == 0);
+  }
+
+  @Test
+  public void testTenVolunteersTenIsolatesMatchAll() {
+    for (int i = 0; i < 10; i++) {
+      isolateTimeSlots.add(new IsolateTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
+      volunteerTimeSlots.add(
+              new VolunteerTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
+    }
+
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    assert (matched.size() == 10);
+  }
+
+  @Test
+  public void test100VolunteersTenIsolatesMatchAll() {
+    for (int i = 0; i < 100; i++) {
+      isolateTimeSlots.add(new IsolateTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
+      volunteerTimeSlots.add(
+              new VolunteerTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
+    }
+
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    assert (matched.size() == 100);
+  }
+
+  @Test
+  public void testTenVolunteersTenIsolatesHalfMatch() {
+    for (int i = 0; i < 10; i++) {
+      isolateTimeSlots.add(new IsolateTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
+    }
+    for (int i = 5; i < 15; i++) {
+      volunteerTimeSlots.add(
+              new VolunteerTimeSlot(now.plus(i, HOURS), now.plus(i + 1, HOURS), null));
+    }
+
+    Set<IsolateTimeSlot> matched =
+            MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
+    assert (matched.size() == 5);
   }
 }

--- a/src/test/java/com/google/vinet/data/MatchingAlgorithmTest.java
+++ b/src/test/java/com/google/vinet/data/MatchingAlgorithmTest.java
@@ -1,17 +1,17 @@
 /*
- * Copyright 2020 Google LLC
+ *  Copyright 2020 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ *      https:www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package com.google.vinet.data;
@@ -19,11 +19,11 @@ package com.google.vinet.data;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.HashSet;
 import java.util.Set;
-import java.time.Clock;
 
 import static java.time.temporal.ChronoUnit.HOURS;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -223,5 +223,29 @@ public class MatchingAlgorithmTest {
     Set<IsolateTimeSlot> matched =
             MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots);
     assert (matched.size() == 0);
+  }
+
+  @Test
+  public void testNotEnoughVolunteers() {
+    isolateTimeSlots.add(new IsolateTimeSlot(now, now.plus(1, HOURS), null));
+    isolateTimeSlots.add(new IsolateTimeSlot(now, now.plus(1, HOURS), new Isolate("a")));
+    isolateTimeSlots.add(new IsolateTimeSlot(now, now.plus(1, HOURS), new Isolate("b")));
+
+    volunteerTimeSlots.add(new VolunteerTimeSlot(now, now.plus(1, HOURS), null));
+    volunteerTimeSlots.add(new VolunteerTimeSlot(now, now.plus(1, HOURS), new Volunteer("c")));
+
+    assert (MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots).size() == 2);
+  }
+
+  @Test
+  public void testNotEnoughIsolates() {
+    isolateTimeSlots.add(new IsolateTimeSlot(now, now.plus(1, HOURS), null));
+    isolateTimeSlots.add(new IsolateTimeSlot(now, now.plus(1, HOURS), new Isolate("a")));
+
+    volunteerTimeSlots.add(new VolunteerTimeSlot(now, now.plus(1, HOURS), null));
+    volunteerTimeSlots.add(new VolunteerTimeSlot(now, now.plus(1, HOURS), new Volunteer("b")));
+    volunteerTimeSlots.add(new VolunteerTimeSlot(now, now.plus(1, HOURS), new Volunteer("c")));
+
+    assert (MatchingAlgorithm.matchTimeSlots(isolateTimeSlots, volunteerTimeSlots).size() == 2);
   }
 }


### PR DESCRIPTION
 Implements the Hopcroft-Karp algorithm for matching isolate and volunteer time slots. Adding edges between the two sets has an O(N * M) worst-case runtime, where N is the number of volunteer time slots and M the number of isolate time slots. Running the Hopcroft-Karp algorithm has a worst-case runtime of O(E * sqrt(V)), where E is the number of edges between the two sets and V the number of vertices in the graph.

A potential issue is that because Hopcroft-Karp is a bipartite-matching algorithm, if, for example, a volunteer were to put themselves down as available for 5 hours, this time slot would only be matched with a single isolate request, even if shorter than 5 hours. The remaining time would simply be unused.
A potential solution is to run the algorithm again with the remaining time and isolate slots, until no more matches can be made.